### PR TITLE
Change output to handle full names

### DIFF
--- a/tally_authors.rb
+++ b/tally_authors.rb
@@ -10,7 +10,7 @@ filename = ARGV[0]
 authorship = {}
 
 File.open(filename).each_line do |line|
-  author = line.gsub(/Author: /, "").chomp.split[0].downcase
+  author = line.gsub(/Author: /, "").chomp.split.tap(&:pop).join(' ').downcase
   if authorship[author]
     authorship[author] += 1
   else


### PR DESCRIPTION
When authors have full names, people with the same first name were getting glommed together. This changes the output to everything before the email, normalized for spaces and capitalization.
