### PR TITLE
Allow for spaces in filenames and paths

### DIFF
--- a/file_stats.sh
+++ b/file_stats.sh
@@ -28,11 +28,18 @@ function legible_output {
 }
 
 function csv_lines_for {
+
+  STORED_IFS=$IFS
+  IFS=$(echo -en "\n\b")
+
   for filename in $(find . -iname "*.$1"); do
     echo "`wc -l $filename` `number_of_commits` `first_commit` `last_commit`" |
     legible_output |
     xargs echo
   done
+
+  IFS=$STORED_IFS
+
 }
 
 function create_csv {


### PR DESCRIPTION
Change field separator IFS (which contains spaces, tabs) before usage in
for-loop. Change back after. This fixes #5 
