### PR TITLE
Add the number of authors and filetype to CSV

### DIFF
--- a/file_stats.sh
+++ b/file_stats.sh
@@ -14,29 +14,35 @@ function number_of_commits {
   git_history | wc -l
 }
  
+function number_of_authors {
+  git log $filename | grep "^Author:" | sort | uniq | wc -l
+}
+
 function legible_output {
   # $2:   filename
   # $1:   lines of code
   # $3:   number of commits
-  # $6:   month (first)
-  # $7:   date (first)
-  # $9:   year (first)
-  # $13:  month (last)
-  # $14:  date (last)
-  # $16:  year (last)
-  awk '{print $2 "," $1 "," $3 "," $6 " " $7 " " $9 "," $13 " " $14 " " $16}'
+  # $4:   number of authors
+  # $5:   filetype
+  # $8:   month (first)
+  # $9:   date (first)
+  # $11:  year (first)
+  # $15:  month (last)
+  # $16:  date (last)
+  # $18:  year (last)
+  awk '{print $2 "," $1 "," $3 "," $4 "," $5 "," $8 " " $9 " " $11 "," $15 " " $16 " " $18 }'
 }
 
 function csv_lines_for {
   for filename in $(find . -iname "*.$1"); do
-    echo "`wc -l $filename` `number_of_commits` `first_commit` `last_commit`" |
+    echo "`wc -l $filename` `number_of_commits` `number_of_authors` $1 `first_commit` `last_commit`" |
     legible_output |
     xargs echo
   done
 }
 
 function create_csv {
-  echo "filename,lines of code,number of commits,date of first commit,date of last commit"
+  echo "filename,lines of code,number of commits,number of authors,filetype,date of first commit,date of last commit"
 
   for argument in "$@"
   do


### PR DESCRIPTION
- Add a function to report the number of unique authors per file
- Add the number of authors and the filetype to the CSV output

This changes the number and order of items in the CSV, which may break existing tools that consume this. 
