### PR TITLE
use git ls-tree instead of find to take advantage of .gitignore

### DIFF
--- a/determine_authors.sh
+++ b/determine_authors.sh
@@ -9,7 +9,7 @@
 #        determine_authors.sh "et_cetera"
 
 function generate_authors_file {
-  for filename in $(find . -iname "*.$1"); do
+  for filename in $(git ls-tree --full-tree -r --name-only HEAD | grep ".*\.$1"); do
     git log $filename | grep Author;
   done
 }


### PR DESCRIPTION
we only care about files in the git repository, so no reason to use find.  This may be faster when a repo may have a lot of code that is in .gitignore because it's loaded from bower or requirements.txt or submodules, or whatever. 

It might be useful to create a git submodule for this repo with a repo purely for test cases (I tested this on the current repo, but it's fairly simple), but that's beyond the scope of this pull request.
